### PR TITLE
Passing offset to ember-tether component

### DIFF
--- a/addon/components/pop-over-positioned.js
+++ b/addon/components/pop-over-positioned.js
@@ -21,6 +21,7 @@ export default TetheredComponent.extend({
   targetAttachment: Ember.computed.reads("popOver.anchor-attachment"),
   attachment:       Ember.computed.reads("popOver.body-attachment"),
   constraints:      Ember.computed.reads("popOver.body-constraints"),
+  offset:           Ember.computed.reads("popOver.offset"),
 
   showingChanged: Ember.on("didInsertElement", Ember.observer("isOpen", function() {
     if (this.get("isOpen")) {


### PR DESCRIPTION
Ember-tether has the "offset" property, which is very useful for us, but it wasn't passed along, so I fixed that.
